### PR TITLE
Add rmDir to System.Directory

### DIFF
--- a/libs/base/System/Directory.idr
+++ b/libs/base/System/Directory.idr
@@ -41,6 +41,9 @@ prim_openDir : String -> PrimIO DirPtr
 %foreign support "idris2_dirClose"
 prim_closeDir : DirPtr -> PrimIO ()
 
+%foreign support "idris2_rmDir"
+prim_rmDir : String -> PrimIO ()
+
 %foreign support "idris2_nextDirEntry"
 prim_dirEntry : DirPtr -> PrimIO (Ptr String)
 
@@ -81,6 +84,10 @@ dirOpen d
 export
 dirClose : Directory -> IO ()
 dirClose (MkDir d) = primIO (prim_closeDir d)
+
+export
+rmDir : String -> IO ()
+rmDir dirName = primIO (prim_rmDir dirName)
 
 export
 dirEntry : Directory -> IO (Either FileError String)

--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -49,6 +49,10 @@ void idris2_dirClose(void* d) {
     free(di);
 }
 
+int idris2_rmDir(char* path) {
+    return rmdir(path);
+}
+
 char* idris2_nextDirEntry(void* d) {
     DirInfo* di = (DirInfo*)d;
     struct dirent* de = readdir(di->dirptr);


### PR DESCRIPTION
I noticed it was missing while I was trying to fix the problem with paths starting with `~`