### PR TITLE
Refactor Utils.String.stripQuotes to avoid double reversion on Strings

### DIFF
--- a/src/Utils/String.idr
+++ b/src/Utils/String.idr
@@ -3,6 +3,8 @@ module Utils.String
 %default total
 
 export
-stripQuotes : String -> String
--- ASSUMPTION! Only total because we know we're getting quoted strings.
-stripQuotes = assert_total (prim__strTail . reverse . prim__strTail . reverse)
+stripQuotes : (str : String) -> String
+stripQuotes str = prim__strSubstr 1 (lengthInt - 2) str
+  where
+    lengthInt : Int
+    lengthInt = fromInteger. natToInteger . length $ str


### PR DESCRIPTION
Small REPL test:
![Screenshot from 2020-05-19 15-47-14](https://user-images.githubusercontent.com/303897/82376679-114ddf80-99e8-11ea-99cd-c1b609b23bf4.png)
Dual of edwinb/Idris2#388