### PR TITLE
Ignoring autogenerated bootstrap/test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,12 @@
 /tests/**/*.so
 /tests/**/*.dylib
 /tests/**/*.dll
+/tests/build/exec
 
 /src/IdrisPaths.idr
+
+/bootstrap/bin/
+/bootstrap/idris2-0*/
+/bootstrap/idris2sh_app/*.so
+/bootstrap/idris2sh_app/idris2-boot.ss
+/bootstrap/lib/


### PR DESCRIPTION
These files were generated when I ran
make bootstrap SCHEME=chez
make install
make test IDRIS2_BOOT=idris2sh
